### PR TITLE
Add retro-styled landing and menu interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WorldSim</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Spectral:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <main id="intro-screen" class="screen active" aria-labelledby="intro-title">
+      <div class="intro-card">
+        <div class="globe-wrapper" role="img" aria-label="WorldSim globe logo">
+          <svg class="globe" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <radialGradient id="ocean" cx="50%" cy="40%" r="70%">
+                <stop offset="0%" stop-color="#8dd4ff" />
+                <stop offset="100%" stop-color="#0a6bb7" />
+              </radialGradient>
+              <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+                <stop offset="0%" stop-color="rgba(255,255,255,0.65)" />
+                <stop offset="40%" stop-color="rgba(255,255,255,0.05)" />
+                <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+              </linearGradient>
+            </defs>
+            <circle cx="100" cy="100" r="92" fill="url(#ocean)" />
+            <path
+              class="continent"
+              d="M63 53c9-11 25-18 39-16 12 2 25 10 31 23 3 8 2 16-5 22-6 6-17 8-26 6-11-2-20-9-27-17-5-6-9-12-12-18z"
+            />
+            <path
+              class="continent"
+              d="M121 86c8-5 19-7 29-4 12 4 21 12 26 23 3 8 0 16-6 22-6 6-15 10-24 11-10 1-19-2-26-8-6-5-8-12-5-18 3-7 8-12 15-16z"
+            />
+            <path
+              class="continent"
+              d="M78 112c7-6 17-8 27-5 10 4 17 11 20 20 2 8-1 17-7 23-6 7-16 12-26 13-9 1-17-3-22-10-5-7-6-16-1-23 3-6 6-12 9-18z"
+            />
+            <path
+              class="continent"
+              d="M50 92c5-4 12-6 18-5 6 1 11 5 14 10 3 6 1 12-4 16-5 4-12 7-19 7-7-1-13-5-16-10-3-5-2-11 3-15 1-1 3-2 4-3z"
+            />
+            <circle cx="72" cy="62" r="4" fill="#b4e4ff" opacity="0.4" />
+            <circle cx="130" cy="128" r="3" fill="#b4e4ff" opacity="0.35" />
+            <path d="M25 100a75 75 0 0 1 150 0 75 75 0 0 1-150 0z" fill="url(#shine)" />
+          </svg>
+        </div>
+        <h1 id="intro-title" class="title">WorldSim</h1>
+        <p class="subtitle">Insert disk... establishing simulation uplink.</p>
+        <button id="continue-btn" class="primary-btn">Continue</button>
+        <p class="hint">Press Enter to continue</p>
+      </div>
+    </main>
+
+    <main id="main-menu" class="screen" aria-labelledby="menu-title">
+      <div class="menu-ambient" aria-hidden="true"></div>
+      <div class="menu-content">
+        <header class="menu-header">
+          <h1 id="menu-title">WorldSim</h1>
+          <p>Simulation Command Console</p>
+        </header>
+        <nav class="menu-options" aria-label="Main menu">
+          <button class="menu-button" data-open="new-sim">New Simulation</button>
+          <button class="menu-button" data-open="saved-sims">Saved Simulations</button>
+          <button class="menu-button" data-open="load-latest">Load Latest Sim</button>
+          <button class="menu-button" data-open="sandbox">Sandbox Mode</button>
+          <button class="menu-button" data-open="settings">Settings</button>
+          <button class="menu-button" data-open="credits">Credits</button>
+          <button class="menu-button" data-open="exit">Exit Program</button>
+        </nav>
+        <footer class="menu-footer">
+          <p>Tip: Forge civilizations, alter climates, script the story of your world.</p>
+        </footer>
+      </div>
+    </main>
+
+    <div
+      id="panel-container"
+      class="panel-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+    >
+      <div class="panel-shade" data-close aria-hidden="true"></div>
+      <div class="panel-wrapper">
+        <section class="panel" data-panel="new-sim" tabindex="-1">
+          <header class="panel-header">
+            <h2>Launch a New Simulation</h2>
+            <p>Pick a scenario to begin your next world-building expedition.</p>
+          </header>
+          <div class="scenario-card">
+            <div class="scenario-header">
+              <h3>WorldSim: Prime Timeline</h3>
+              <span class="badge">Featured</span>
+            </div>
+            <p>
+              Our flagship scenario featuring a living, breathing world with evolving climates,
+              cultures, and unexpected events.
+            </p>
+            <ul class="scenario-details">
+              <li>🌍 Balanced Earth-like biomes with adaptive ecosystems.</li>
+              <li>🧬 Procedural civilizations that learn, trade, and wage war.</li>
+              <li>⛈️ Dynamic weather, disasters, and celestial phenomena.</li>
+            </ul>
+            <div class="scenario-actions">
+              <button class="primary-btn" data-focus>Launch Scenario</button>
+              <button class="secondary-btn" data-close>Back to Menu</button>
+            </div>
+          </div>
+          <p class="coming-soon">More simulation archetypes arriving in future updates.</p>
+        </section>
+
+        <section class="panel" data-panel="saved-sims" tabindex="-1">
+          <header class="panel-header">
+            <h2>Saved Simulations</h2>
+            <p>Your archived worlds will appear here for quick deployment.</p>
+          </header>
+          <div class="empty-state">
+            <span class="empty-icon" aria-hidden="true">📁</span>
+            <p>No saved simulations detected.</p>
+            <p class="muted">
+              Start a new sim to create save points, or import saves from another terminal.
+            </p>
+          </div>
+          <button class="secondary-btn" data-close>Return to Menu</button>
+        </section>
+
+        <section class="panel" data-panel="load-latest" tabindex="-1">
+          <header class="panel-header">
+            <h2>Load Latest Simulation</h2>
+            <p>Resume exactly where you left off in your most recent session.</p>
+          </header>
+          <div class="log-entry">
+            <p class="muted">Last session: <strong>Pending</strong> — no previous run recorded.</p>
+            <p>
+              Once you have explored a world, the command console will list its timestamp and
+              summary here for instant relaunch.
+            </p>
+          </div>
+          <div class="panel-actions">
+            <button class="primary-btn" disabled>Load Latest</button>
+            <button class="secondary-btn" data-close>Return to Menu</button>
+          </div>
+        </section>
+
+        <section class="panel" data-panel="sandbox" tabindex="-1">
+          <header class="panel-header">
+            <h2>Sandbox Mode</h2>
+            <p>Craft a bespoke universe with fine-grained control over its parameters.</p>
+          </header>
+          <form class="sandbox-grid" action="#" method="dialog">
+            <label class="sandbox-field">
+              <span>Climate Profile</span>
+              <select>
+                <option>Temperate Baseline</option>
+                <option>Frozen Frontier</option>
+                <option>Equatorial Archipelago</option>
+                <option>Desert Expanse</option>
+              </select>
+            </label>
+            <label class="sandbox-field">
+              <span>Geological Activity</span>
+              <input type="range" min="0" max="10" value="6" />
+            </label>
+            <label class="sandbox-field">
+              <span>Population Seed</span>
+              <select>
+                <option>Nomadic Tribes</option>
+                <option>Settled Agrarians</option>
+                <option>Industrial Age</option>
+                <option>Post-Digital</option>
+              </select>
+            </label>
+            <label class="sandbox-field">
+              <span>Event Intensity</span>
+              <input type="range" min="0" max="10" value="4" />
+            </label>
+            <label class="sandbox-field">
+              <span>Tech Progression Speed</span>
+              <input type="range" min="0" max="10" value="5" />
+            </label>
+            <label class="sandbox-field">
+              <span>Custom Seed</span>
+              <input type="text" placeholder="Optional world seed" />
+            </label>
+          </form>
+          <div class="panel-actions">
+            <button class="primary-btn">Initialize Sandbox</button>
+            <button class="secondary-btn" data-close>Return to Menu</button>
+          </div>
+        </section>
+
+        <section class="panel" data-panel="settings" tabindex="-1">
+          <header class="panel-header">
+            <h2>Settings</h2>
+            <p>Tune the audiovisual fidelity of your command console.</p>
+          </header>
+          <div class="settings-list">
+            <label class="setting">
+              <span>Music Volume</span>
+              <input type="range" min="0" max="100" value="70" />
+            </label>
+            <label class="setting">
+              <span>Sound Effects</span>
+              <input type="range" min="0" max="100" value="80" />
+            </label>
+            <label class="setting">
+              <span>Brightness</span>
+              <input type="range" min="0" max="100" value="50" />
+            </label>
+            <label class="setting">
+              <span>Difficulty Preset</span>
+              <select>
+                <option>Explorer</option>
+                <option>Strategist</option>
+                <option>Mythic</option>
+              </select>
+            </label>
+            <label class="setting toggle">
+              <span>CRT Scanlines</span>
+              <input type="checkbox" checked />
+            </label>
+          </div>
+          <button class="secondary-btn" data-close>Return to Menu</button>
+        </section>
+
+        <section class="panel" data-panel="credits" tabindex="-1">
+          <header class="panel-header">
+            <h2>Credits</h2>
+            <p>A tribute to the explorers charting new worlds within WorldSim.</p>
+          </header>
+          <ul class="credits-list">
+            <li><strong>Creative Direction:</strong> You</li>
+            <li><strong>Lead Simulation Architect:</strong> Imagination Engine</li>
+            <li><strong>Historical Consultant:</strong> Alternate Timelines Guild</li>
+            <li><strong>Audio Engineering:</strong> Quantum Echo Chamber</li>
+          </ul>
+          <p class="muted">Inspired by the grand strategy classics of the disk-era frontier.</p>
+          <button class="secondary-btn" data-close>Return to Menu</button>
+        </section>
+
+        <section class="panel" data-panel="exit" tabindex="-1">
+          <header class="panel-header">
+            <h2>Exit WorldSim</h2>
+            <p>Prepare to power down the simulation console.</p>
+          </header>
+          <p>
+            Your progress will be saved once the primary scenarios are available. For now, feel free
+            to continue exploring or close this window when you're ready.
+          </p>
+          <div class="panel-actions">
+            <button class="primary-btn" disabled>Exit to Desktop</button>
+            <button class="secondary-btn" data-close>Return to Menu</button>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,107 @@
+(() => {
+  const introScreen = document.getElementById('intro-screen');
+  const mainMenu = document.getElementById('main-menu');
+  const continueBtn = document.getElementById('continue-btn');
+  const panelOverlay = document.getElementById('panel-container');
+  const panelShade = panelOverlay.querySelector('.panel-shade');
+  const panelWrapper = panelOverlay.querySelector('.panel-wrapper');
+  const panels = Array.from(panelWrapper.querySelectorAll('.panel'));
+  const menuButtons = Array.from(document.querySelectorAll('[data-open]'));
+  const closeTriggers = Array.from(panelOverlay.querySelectorAll('[data-close]'));
+  const scanlinesLayer = document.querySelector('.scanlines');
+  const scanlinesToggle = panelOverlay.querySelector(
+    '[data-panel="settings"] input[type="checkbox"]'
+  );
+
+  let activeButton = null;
+
+  function showMainMenu() {
+    if (!introScreen.classList.contains('active')) return;
+    introScreen.classList.remove('active');
+    mainMenu.classList.add('active');
+  }
+
+  function openPanel(name, trigger) {
+    const panelToShow = panels.find((panel) => panel.dataset.panel === name);
+    if (!panelToShow) return;
+
+    panels.forEach((panel) => {
+      panel.classList.toggle('active', panel === panelToShow);
+    });
+
+    panelOverlay.classList.add('visible');
+    panelOverlay.setAttribute('aria-hidden', 'false');
+
+    if (trigger) {
+      if (activeButton) {
+        activeButton.classList.remove('selected');
+      }
+      trigger.classList.add('selected');
+      activeButton = trigger;
+    }
+
+    window.setTimeout(() => {
+      const focusTarget =
+        panelToShow.querySelector('[data-focus]') ||
+        panelToShow.querySelector('button, select, input, a');
+      if (focusTarget) {
+        focusTarget.focus({ preventScroll: true });
+      }
+    }, 40);
+  }
+
+  function closePanel() {
+    if (!panelOverlay.classList.contains('visible')) return;
+    panelOverlay.classList.remove('visible');
+    panelOverlay.setAttribute('aria-hidden', 'true');
+    panels.forEach((panel) => panel.classList.remove('active'));
+    if (activeButton) {
+      activeButton.classList.remove('selected');
+      activeButton = null;
+    }
+  }
+
+  continueBtn?.addEventListener('click', showMainMenu);
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      if (introScreen.classList.contains('active')) {
+        event.preventDefault();
+        showMainMenu();
+        return;
+      }
+    }
+
+    if (event.key === 'Escape') {
+      closePanel();
+    }
+  });
+
+  menuButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const panelName = button.dataset.open;
+      openPanel(panelName, button);
+    });
+  });
+
+  closeTriggers.forEach((trigger) => {
+    trigger.addEventListener('click', () => {
+      closePanel();
+    });
+  });
+
+  panelShade.addEventListener('click', closePanel);
+
+  panelOverlay.addEventListener('transitionend', (event) => {
+    if (event.target === panelOverlay && !panelOverlay.classList.contains('visible')) {
+      panels.forEach((panel) => panel.classList.remove('active'));
+    }
+  });
+
+  if (scanlinesToggle) {
+    scanlinesToggle.addEventListener('change', () => {
+      if (!scanlinesLayer) return;
+      scanlinesLayer.style.display = scanlinesToggle.checked ? 'block' : 'none';
+    });
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,616 @@
+:root {
+  --bg-primary: #05070f;
+  --bg-secondary: #15182a;
+  --bg-tertiary: #1f2338;
+  --accent: #d4a454;
+  --accent-bright: #f7e4b0;
+  --text-primary: #f6ead4;
+  --text-muted: #c1b7a0;
+  --panel-bg: rgba(10, 9, 18, 0.92);
+  --panel-border: rgba(219, 164, 76, 0.45);
+  --panel-shadow: rgba(0, 0, 0, 0.65);
+  --button-bg: rgba(57, 42, 23, 0.85);
+  --button-hover: rgba(91, 64, 33, 0.95);
+  --button-active: rgba(125, 86, 43, 1);
+  --button-border: rgba(244, 195, 109, 0.55);
+  --screen-transition: 0.6s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Spectral', 'Times New Roman', serif;
+  color: var(--text-primary);
+  background: radial-gradient(ellipse at top, #2b3551 0%, #0a0c17 65%, #05060b 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -10%;
+  background-image:
+    radial-gradient(1px 1px at 20% 30%, rgba(255, 255, 255, 0.25), transparent 35%),
+    radial-gradient(1.2px 1.2px at 70% 10%, rgba(255, 255, 255, 0.15), transparent 40%),
+    radial-gradient(1px 1px at 45% 80%, rgba(255, 255, 255, 0.22), transparent 35%),
+    radial-gradient(1.5px 1.5px at 90% 60%, rgba(255, 255, 255, 0.18), transparent 40%),
+    radial-gradient(1.2px 1.2px at 10% 75%, rgba(255, 255, 255, 0.18), transparent 45%);
+  z-index: 0;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at center, transparent 0%, rgba(0, 0, 0, 0.7) 90%);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  opacity: 0.25;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  z-index: 10;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Cinzel', 'Trajan Pro', serif;
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+button,
+select,
+input,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+a {
+  color: var(--accent-bright);
+}
+
+.screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--screen-transition);
+  z-index: 1;
+}
+
+.screen.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#intro-screen {
+  background: linear-gradient(
+      135deg,
+      rgba(9, 13, 24, 0.95),
+      rgba(8, 9, 18, 0.92)
+    ),
+    radial-gradient(circle at 50% 20%, rgba(72, 94, 141, 0.25), transparent 60%);
+}
+
+.intro-card {
+  background: rgba(9, 12, 21, 0.85);
+  border: 1px solid rgba(212, 164, 84, 0.5);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.7);
+  padding: clamp(2.5rem, 4vw, 4rem);
+  text-align: center;
+  max-width: 520px;
+  width: min(90vw, 520px);
+  position: relative;
+  backdrop-filter: blur(6px);
+}
+
+.intro-card::after {
+  content: '';
+  position: absolute;
+  inset: 1rem;
+  border: 1px solid rgba(255, 243, 217, 0.12);
+  pointer-events: none;
+}
+
+.globe-wrapper {
+  width: clamp(180px, 30vw, 260px);
+  margin: 0 auto 1.5rem;
+  padding: 1.2rem;
+  background: radial-gradient(circle at 50% 45%, rgba(255, 255, 255, 0.2), transparent 70%);
+  border-radius: 50%;
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.5), 0 15px 30px rgba(0, 0, 0, 0.3);
+}
+
+.globe {
+  display: block;
+  width: 100%;
+  filter: drop-shadow(0 8px 18px rgba(10, 30, 60, 0.65));
+}
+
+.continent {
+  fill: #7bd463;
+  filter: drop-shadow(0 3px 4px rgba(0, 0, 0, 0.3));
+  opacity: 0.95;
+}
+
+.title {
+  font-size: clamp(2.4rem, 5vw, 3.8rem);
+  margin-bottom: 0.6rem;
+  color: var(--accent-bright);
+  text-shadow: 0 0 18px rgba(212, 164, 84, 0.6);
+}
+
+.subtitle {
+  font-size: 1rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin-bottom: 2rem;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+}
+
+button {
+  cursor: pointer;
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  padding: 0.75rem 2.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent-bright);
+  transition: background 0.25s ease, transform 0.2s ease, box-shadow 0.25s ease;
+  box-shadow: inset 0 0 0 rgba(0, 0, 0, 0.2), 0 12px 20px rgba(0, 0, 0, 0.35);
+  position: relative;
+}
+
+button::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  pointer-events: none;
+}
+
+button:hover {
+  background: var(--button-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 24px rgba(0, 0, 0, 0.4);
+}
+
+button:active {
+  background: var(--button-active);
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.35);
+}
+
+button:focus-visible {
+  outline: 2px solid rgba(255, 239, 203, 0.9);
+  outline-offset: 3px;
+}
+
+button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary-btn {
+  background: linear-gradient(180deg, rgba(215, 160, 74, 0.85), rgba(108, 67, 25, 0.85));
+  color: #1c120a;
+  font-weight: 600;
+}
+
+.primary-btn:hover {
+  background: linear-gradient(180deg, rgba(240, 198, 106, 0.92), rgba(128, 82, 31, 0.95));
+}
+
+.primary-btn::after {
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.secondary-btn {
+  background: rgba(19, 17, 28, 0.75);
+  color: var(--accent-bright);
+}
+
+.secondary-btn:hover {
+  background: rgba(32, 27, 43, 0.85);
+}
+
+#main-menu {
+  background: linear-gradient(160deg, rgba(7, 9, 18, 0.92), rgba(4, 6, 12, 0.95));
+}
+
+.menu-ambient {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 20%, rgba(109, 86, 49, 0.45), transparent 55%),
+    radial-gradient(circle at 70% 70%, rgba(40, 76, 110, 0.35), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0.5;
+}
+
+.menu-content {
+  position: relative;
+  text-align: center;
+  padding: clamp(2rem, 5vw, 4.5rem);
+  background: rgba(9, 10, 20, 0.82);
+  border: 1px solid rgba(212, 164, 84, 0.35);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.7);
+  max-width: 480px;
+  width: min(90vw, 480px);
+}
+
+.menu-content::before {
+  content: '';
+  position: absolute;
+  inset: 1rem;
+  border: 1px solid rgba(255, 243, 217, 0.1);
+  pointer-events: none;
+}
+
+.menu-header h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  color: var(--accent-bright);
+  text-shadow: 0 0 18px rgba(212, 164, 84, 0.6);
+}
+
+.menu-header p {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.55);
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  margin-bottom: 2rem;
+}
+
+.menu-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.menu-button {
+  width: 100%;
+  padding: 0.95rem 2rem;
+  font-size: 0.9rem;
+  background: rgba(23, 20, 32, 0.9);
+  color: var(--accent-bright);
+  border: 1px solid rgba(255, 215, 149, 0.35);
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+.menu-button::after {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.menu-button:hover {
+  background: rgba(54, 41, 24, 0.95);
+}
+
+.menu-button.selected {
+  background: linear-gradient(180deg, rgba(221, 171, 95, 0.9), rgba(92, 62, 31, 0.95));
+  color: #1c1309;
+  box-shadow: 0 0 18px rgba(215, 160, 74, 0.45), 0 12px 22px rgba(0, 0, 0, 0.55);
+}
+
+.menu-footer {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.85rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.panel-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+  z-index: 5;
+}
+
+.panel-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.panel-shade {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 5, 12, 0.75);
+  backdrop-filter: blur(2px);
+}
+
+.panel-wrapper {
+  position: relative;
+  width: min(90vw, 800px);
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 28px 60px var(--panel-shadow);
+  padding: clamp(1.8rem, 4vw, 3rem);
+}
+
+.panel {
+  display: none;
+  animation: panelFade 0.35s ease;
+}
+
+.panel.active {
+  display: block;
+}
+
+.panel-header p {
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 1.5rem;
+}
+
+.scenario-card {
+  background: rgba(20, 21, 36, 0.88);
+  border: 1px solid rgba(215, 160, 74, 0.35);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  margin-bottom: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.scenario-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.badge {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  background: rgba(212, 164, 84, 0.25);
+  border: 1px solid rgba(212, 164, 84, 0.6);
+  padding: 0.35rem 0.6rem;
+  color: var(--accent-bright);
+}
+
+.scenario-details {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.scenario-details li {
+  background: rgba(12, 12, 21, 0.6);
+  padding: 0.65rem 0.9rem;
+  border-left: 3px solid rgba(215, 160, 74, 0.5);
+  font-size: 0.95rem;
+}
+
+.scenario-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.coming-soon {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.empty-state {
+  text-align: center;
+  background: rgba(16, 17, 29, 0.75);
+  border: 1px solid rgba(212, 164, 84, 0.2);
+  padding: 2rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.empty-icon {
+  font-size: 2.5rem;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.log-entry {
+  background: rgba(19, 18, 30, 0.75);
+  border: 1px solid rgba(212, 164, 84, 0.2);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.sandbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.sandbox-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(15, 16, 28, 0.65);
+  border: 1px solid rgba(215, 160, 74, 0.25);
+  padding: 0.9rem 1rem;
+}
+
+.sandbox-field span {
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+select,
+input[type='text'] {
+  background: rgba(20, 21, 36, 0.9);
+  border: 1px solid rgba(215, 160, 74, 0.3);
+  color: var(--text-primary);
+  padding: 0.5rem 0.75rem;
+  appearance: none;
+}
+
+input[type='text']::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+input[type='range'] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.settings-list {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.setting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(15, 16, 28, 0.65);
+  border: 1px solid rgba(215, 160, 74, 0.25);
+  padding: 0.8rem 1rem;
+}
+
+.setting span {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.setting.toggle {
+  justify-content: flex-start;
+  gap: 1.5rem;
+}
+
+.setting.toggle input[type='checkbox'] {
+  width: 1.4rem;
+  height: 1.4rem;
+  accent-color: var(--accent);
+}
+
+.credits-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+@keyframes panelFade {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 640px) {
+  .menu-content,
+  .intro-card {
+    padding: 2rem 1.5rem;
+  }
+
+  .menu-header p {
+    letter-spacing: 0.25em;
+  }
+
+  button {
+    letter-spacing: 0.15em;
+  }
+
+  .panel-wrapper {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .scenario-actions,
+  .panel-actions {
+    flex-direction: column;
+  }
+
+  .sandbox-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- create a retro-inspired landing screen with a custom SVG globe and continue prompt
- implement an Age-of-Empires style main menu with scenario, sandbox, and settings overlays
- add JavaScript to transition screens, manage modal panels, and toggle the CRT scanline effect

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf8140224083238c3dd868551c36a0